### PR TITLE
chore: update cacert.pem, source from artifactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Chef cookbook that downloads and updates a cacert.pem file and sets the SSL_CERT_FILE environment variable.
 
+## Updating
+
+The cacert.pem file contains a list of public root CA certificates.  It is used by the OpenSSL library to validate SSL connections.  The file must be kept up to date in order to ensure communication is possible with all public secure sites.
+
+New versions of cacert.pem can be obtained from the [official curl homepage](https://curl.haxx.se/docs/caextract.html).  The curl maintainers ask that their site not be used as a primary download server.  As such, we mirror date stamped copies of cacert.pem in the [cacert-local repo](http://artrepo.daptiv.com/artifactory/webapp/#/artifacts/browse/tree/General/cacert-local) in Artifactory.
+
+To update the cacert.pem file installed by this cookbook:
+* Download the latest date stamped cacert.pem file (ex. `cacert-2018-12-05.pem`) from the [official curl homepage](https://curl.haxx.se/docs/caextract.html).
+* Upload it to the [cacert-local repo](http://artrepo.daptiv.com/artifactory/webapp/#/artifacts/browse/tree/General/cacert-local) in Artifactory.
+* Update `default['cacert']['pem_url']` in [attributes/default.rb](attributes/default.rb).
+* Ensure the cookbook's [TeamCity build](http://teamcity.daptiv.com/viewType.html?buildTypeId=Chef_Cookbooks_Cacert) passes.
+
 ## Contributing
 
 1. Fork the repository on GitHub.
@@ -13,4 +25,4 @@ Chef cookbook that downloads and updates a cacert.pem file and sets the SSL_CERT
 
 ## License and Authors
 
-Author:: Changepoint Engineering (cpc_sea_teamengineering@changepoint.com) 
+Author:: Changepoint Engineering (cpc_sea_teamengineering@changepoint.com)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
 #:encoding utf-8
-default['cacert']['pem_url'] = 'http://curl.haxx.se/ca/cacert.pem'
+default['cacert']['pem_url'] =
+  'http://artrepo.daptiv.com/artifactory/simple/cacert-local/' \
+  'cacert-2018-12-05.pem'
 default['cacert']['install_path'] = Chef::Config[:file_cache_path]


### PR DESCRIPTION
- Download cacert.pem from Artifactory by default, rather than the curl homepage.  They don't want people using their site as a primary download server.
- Change to using date stamped pem file in Artifactory, rather than generically named one.  That way it should be more obvious whether the pem file is fresh or stale.  (Now you just have to look at the recipe, rather than downloading and examining the file hosted in Artifactory.)
- Added instructions README on how to update the cacert.pem file deployed by the cookbook.