### PR TITLE
fix: do not install cacert to chef cache dir

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,18 +17,6 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu
-    driver:
-      block_device_mappings:
-        - device_name: /dev/sda1
-          ebs:
-            delete_on_termination: true
-      image_search:
-        "name": <%= ENV['EC2_UBUNTU_IMAGE_NAME'] %>
-    transport:
-      name: ssh
-      username: <%= ENV['SSH_USER'] %>
-      ssh_key: <%= ENV['SSH_KEY'] %>
   - name: windows
     driver:
       image_search:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # cacert
 
-Chef cookbook that downloads and updates a cacert.pem file and sets the SSL_CERT_FILE environment variable.
+Chef cookbook that downloads and updates a cacert.pem file on Windows and sets the SSL_CERT_FILE environment variable.
+
+## Requirements
+
+### Platform
+* Microsoft Windows
 
 ## Updating
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,4 +2,4 @@
 default['cacert']['pem_url'] =
   'http://artrepo.daptiv.com/artifactory/simple/cacert-local/' \
   'cacert-2018-12-05.pem'
-default['cacert']['install_path'] = Chef::Config[:file_cache_path]
+default['cacert']['install_path'] = 'c:\\chef'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,15 +8,12 @@
 # All rights reserved - Do Not Redistribute
 #
 
-remote_file "#{node['cacert']['install_path']}/cacert.pem" do
-  source node['cacert']['pem_url']
-end
-
 if platform?('windows')
+  remote_file "#{node['cacert']['install_path']}\\cacert.pem" do
+    source node['cacert']['pem_url']
+  end
+
   env 'SSL_CERT_FILE' do
     value "#{node['cacert']['install_path']}\\cacert.pem"
   end
-else
-  # add unix env var here
-  puts 'Adding SSL_CERT_FILE enviroment variable.'
 end


### PR DESCRIPTION
- Switch cacert file installation location from the Chef cache path directory to a fixed location on the system drive.  This is good for two reasons.  First, it ensures that the cacert file is not in the Chef cache directory, which can periodically be cleared.  Second, since the Chef cache directory is initially on the C: drive, then gets changed to the D: drive later, this prevents the cacert file from being installed in two locations!

- Update the SSL_CERT_FILE environment variable to contain all forward slashes, instead of a mix of forward and back slashes.

https://daptiv.tpondemand.com/entity/91972-update-cacert-and-daptiv_buildagent_windows_role-cookbooks-to