### PR TITLE
91972 update cacert location

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,18 @@ provisioner:
   name: chef_zero
 
 platforms:
+  - name: ubuntu
+    driver:
+      block_device_mappings:
+        - device_name: /dev/sda1
+          ebs:
+            delete_on_termination: true
+      image_search:
+        "name": <%= ENV['EC2_UBUNTU_IMAGE_NAME'] %>
+    transport:
+      name: ssh
+      username: <%= ENV['SSH_USER'] %>
+      ssh_key: <%= ENV['SSH_KEY'] %>
   - name: windows
     driver:
       image_search:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,18 +17,6 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu
-    driver:
-      block_device_mappings:
-        - device_name: /dev/sda1
-          ebs:
-            delete_on_termination: true
-      image_search:
-        "name": <%= ENV['EC2_UBUNTU_IMAGE_NAME'] %>
-    transport:
-      name: ssh
-      username: <%= ENV['SSH_USER'] %>
-      ssh_key: <%= ENV['SSH_KEY'] %>
   - name: windows
     driver:
       image_search:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Changepoint
+Copyright (c) 2019 Changepoint
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # cacert
 
-Chef cookbook that downloads and updates a cacert.pem file on Windows and sets the SSL_CERT_FILE environment variable.
+Chef cookbook that downloads and updates a cacert.pem file and sets the SSL_CERT_FILE environment variable.
 
 ## Requirements
 
 ### Platform
-* Microsoft Windows
+* Linux
+* Windows
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # cacert
 
-Chef cookbook that downloads and updates a cacert.pem file and sets the SSL_CERT_FILE environment variable.
+Chef cookbook that downloads and updates a cacert.pem file on Windows and sets the SSL_CERT_FILE environment variable.
+
+## Requirements
+
+### Platform
+* Microsoft Windows
 
 ## Updating
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,4 +2,5 @@
 default['cacert']['pem_url'] =
   'http://artrepo.daptiv.com/artifactory/simple/cacert-local/' \
   'cacert-2018-12-05.pem'
-default['cacert']['install_path'] = 'c:\\chef'
+default['cacert']['linux']['install_path'] = '/etc/chef'
+default['cacert']['windows']['install_path'] = 'c:\\chef'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,4 +2,4 @@
 default['cacert']['pem_url'] =
   'http://artrepo.daptiv.com/artifactory/simple/cacert-local/' \
   'cacert-2018-12-05.pem'
-default['cacert']['install_path'] = Chef::Config[:file_cache_path]
+default['cacert']['install_path'] = 'c:\\chef'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,5 +9,5 @@ version File.exist?(ver_path) ? IO.read(ver_path).chomp : '0.2.1'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 issues_url 'https://github.com/daptiv/daptiv_sso/issues'
 source_url 'https://github.com/daptiv/daptiv_sso/'
-supports 'ubuntu'
+supports 'linux'
 supports 'windows'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,12 +11,13 @@
 if platform?('windows')
   cert_file_path = "#{node['cacert']['windows']['install_path']}\\cacert.pem"
 
-  directory 'install_path' do
+  directory 'cacert installation directory' do
     path node['cacert']['windows']['install_path']
     action :create
   end
 
-  remote_file cert_file_path do
+  remote_file 'cacert file' do
+    path cert_file_path
     source node['cacert']['pem_url']
   end
 
@@ -26,7 +27,7 @@ if platform?('windows')
 else
   cert_file_path = "#{node['cacert']['linux']['install_path']}/cacert.pem"
 
-  directory 'install_path' do
+  directory 'cacert installation directory' do
     path node['cacert']['linux']['install_path']
     owner 'root'
     group 'root'
@@ -34,7 +35,8 @@ else
     action :create
   end
 
-  remote_file cert_file_path do
+  remote_file 'cacert file' do
+    path cert_file_path
     source node['cacert']['pem_url']
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,15 +8,12 @@
 # All rights reserved - Do Not Redistribute
 #
 
-remote_file "#{node['cacert']['install_path']}/cacert.pem" do
-  source node['cacert']['pem_url']
-end
-
 if platform?('windows')
+  remote_file "#{node['cacert']['install_path']}\\cacert.pem" do
+    source node['cacert']['pem_url']
+  end
+
   env 'SSL_CERT_FILE' do
     value "#{node['cacert']['install_path']}\\cacert.pem"
   end
-else
-  # add unix env var here
-  puts 'Adding SSL_CERT_FILE enviroment variable.'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,11 +9,40 @@
 #
 
 if platform?('windows')
-  remote_file "#{node['cacert']['install_path']}\\cacert.pem" do
+  cert_file_path = "#{node['cacert']['windows']['install_path']}\\cacert.pem"
+
+  directory 'install_path' do
+    path node['cacert']['windows']['install_path']
+    action :create
+  end
+
+  remote_file cert_file_path do
     source node['cacert']['pem_url']
   end
 
   env 'SSL_CERT_FILE' do
-    value "#{node['cacert']['install_path']}\\cacert.pem"
+    value cert_file_path
+  end
+else
+  cert_file_path = "#{node['cacert']['linux']['install_path']}/cacert.pem"
+
+  directory 'install_path' do
+    path node['cacert']['linux']['install_path']
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
+
+  remote_file cert_file_path do
+    source node['cacert']['pem_url']
+  end
+
+  ruby_block 'edit /etc/environment' do
+    block do
+      line = "SSL_CERT_FILE=#{cert_file_path}"
+      File.open('/etc/environment', 'a') { |f| f.write(line) }
+    end
+    not_if 'grep SSL_CERT_FILE /etc/environment'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,10 +12,6 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 
-  # Select the Fauxhai template to load
-  config.platform = 'windows'
-  config.version = '2008R2'
-
   config.before(:each) do
     # Set some common global ENV vars used by Windows cookbooks
     ENV['WINDIR'] = 'C:\Windows'
@@ -25,5 +21,7 @@ RSpec.configure do |config|
     allow_any_instance_of(Chef::Recipe).to receive(
       :registry_key_exists?
     ).and_return(false)
+
+    stub_command('grep SSL_CERT_FILE /etc/environment').and_return(false)
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -10,14 +10,70 @@
 
 require 'spec_helper'
 
+# rubocop:disable BlockLength
 describe 'cacert::default' do
-  context 'When all attributes are default, on an unspecified platform' do
+  context 'On the Windows platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
+      runner = ChefSpec::ServerRunner.new(
+        platform: 'windows',
+        version: '2012R2'
+      )
       runner.converge(described_recipe)
     end
+
     it 'converges successfully' do
       chef_run # This should not raise an error
     end
+
+    it 'creates the cacert installation directory' do
+      expect(chef_run).to create_directory(
+        'cacert installation directory'
+      )
+    end
+
+    it 'downloads the cacert file' do
+      expect(chef_run).to create_remote_file(
+        'cacert file'
+      )
+    end
+
+    it 'sets the SSL_CERT_FILE environment variable' do
+      expect(chef_run).to create_env(
+        'SSL_CERT_FILE'
+      )
+    end
+  end
+
+  context 'On the Linux platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(
+        platform: 'ubuntu',
+        version: '18.04'
+      )
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+
+    it 'creates the cacert installation directory' do
+      expect(chef_run).to create_directory(
+        'cacert installation directory'
+      )
+    end
+
+    it 'downloads the cacert file' do
+      expect(chef_run).to create_remote_file(
+        'cacert file'
+      )
+    end
+
+    it 'sets the SSL_CERT_FILE environment variable' do
+      expect(chef_run).to run_ruby_block(
+        'edit /etc/environment'
+      )
+    end
   end
 end
+# rubocop:enable BlockLength


### PR DESCRIPTION
- Instead of downloading the cacert file to the Chef cache directory, which is an illogical choice for a place to store long lived files, now we download to the Chef configuration directory.  Either /etc/chef on Linux, or C:\chef on Windows.  If for some reason the directory does not exist, we will create it too.

- Actually support Linux!  Previously, if the host was Linux, all we did was download the cacert file...which is totally pointless on its own.  Now we set the SSL_CERT_FILE variable in /etc/environment, which is the global environment variable file.

https://daptiv.tpondemand.com/entity/91972-update-cacert-and-daptiv_buildagent_windows_role-cookbooks-to